### PR TITLE
Adding option for a second environment secret

### DIFF
--- a/.github/workflows/run-addon.yml
+++ b/.github/workflows/run-addon.yml
@@ -44,6 +44,7 @@ jobs:
           DC_USERNAME: ${{ secrets.dc_username }}
           DC_PASSWORD: ${{ secrets.dc_password }}
           TOKEN: ${{ secrets.token }}
+          KEY: ${{ secrets.key }}
       - name: Commit and push if it changed
         if: inputs.git-commit
         run: |-

--- a/.github/workflows/run-addon.yml
+++ b/.github/workflows/run-addon.yml
@@ -22,6 +22,8 @@ on:
         required: false
       token:
         required: false
+      key:
+       required: false
 
 jobs:
   Run-Add-On:


### PR DESCRIPTION
Many APIs have an access key and a secret key, both  of which would be good to have as secrets and remove from disclosure in code. Adding the option for a second  environment secret in the parent workflow makes it so that developers can have more accessibility. I've named it key, just to be generic.